### PR TITLE
Add test setup with Vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 Simple browser game prototype. Open `src/index.html` in your browser to play.
 
 All styles are located in `src/style.css` and the game logic is in `src/game.js`.
+
+## Running Tests
+
+Install dependencies with `npm install` and then run tests using:
+
+```bash
+npm test
+```
+
+This will execute the Vitest suite.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint \"src/**/*.{js}\"",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier --write \"src/**/*.{js,css,html}\"",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "prepare": "husky install"
   },
   "keywords": [],
@@ -24,6 +24,8 @@
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-config-prettier": "^9.0.0",
     "husky": "^9.0.0",
-    "lint-staged": "^15.0.0"
+    "lint-staged": "^15.0.0",
+    "vitest": "^1.0.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/game.test.js
+++ b/src/game.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Setup DOM elements required by game.js
+function setupDOM() {
+  document.body.innerHTML = `
+    <canvas id="gameCanvas"></canvas>
+    <div id="score"></div>
+    <div id="lives"></div>
+    <div id="gameOverScreen"></div>
+    <div id="finalScore"></div>
+    <button id="restartButton"></button>
+    <div id="messageBox"></div>
+  `;
+}
+
+describe('game initialization', () => {
+  it('attaches to canvas element', async () => {
+    vi.useFakeTimers();
+    global.requestAnimationFrame = vi.fn();
+    setupDOM();
+
+    await import('./game.js');
+
+    const canvas = document.getElementById('gameCanvas');
+    expect(canvas.width).toBe(800);
+    expect(canvas.height).toBe(450);
+  });
+});

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -5,4 +5,7 @@ export default defineConfig({
   server: {
     open: true,
   },
+  test: {
+    environment: 'jsdom',
+  },
 });


### PR DESCRIPTION
## Summary
- install Vitest and jsdom as dev dependencies
- configure the test script to run Vitest
- configure Vitest in `vite.config.mjs`
- add a simple DOM initialization test for `game.js`
- document how to run the tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415a8da698832ea8b52b29ea467191